### PR TITLE
Workspace must be open to create example file

### DIFF
--- a/templates/tree-editor/README.md
+++ b/templates/tree-editor/README.md
@@ -4,7 +4,7 @@ The example extension demonstrates how to build tree editors in Eclipse Theia, w
 
 ## How to use the example tree editor
 
-In the running application, open the menu "Tree Editor"=>"New Example File".
+In the running application, open the menu "Tree Editor"=>"New Example File" (a workspace must be opened).
 The created `.tree` file will automatically be opened with the example tree editor.
 The left side of the editor shows the hierarchy of the JSON data allowing you to create new children and delete nodes.
 The right site shows the properties of a selected node and allows the modification of the same.

--- a/templates/tree-editor/example-file/example-file-command.ts
+++ b/templates/tree-editor/example-file/example-file-command.ts
@@ -8,6 +8,7 @@ import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { FileSystemUtils } from '@theia/filesystem/lib/common';
 import { inject, injectable } from 'inversify';
 import { OpenerService } from '@theia/core/lib/browser';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
 
 export const NewTreeExampleFileCommand: Command = {
     id: '<%= params.extensionPath %>-tree.newExampleFile',
@@ -23,8 +24,14 @@ export class NewTreeExampleFileCommandHandler implements SingleUriCommandHandler
         protected readonly fileService: FileService,
         @inject(ILogger)
         protected readonly logger: ILogger,
+        @inject(WorkspaceService)
+        protected readonly workspaceService: WorkspaceService
     ) { }
     
+    isEnabled() {
+        return this.workspaceService.opened;
+    }
+
     async execute(uri: URI) {
         const stat = await this.fileService.resolve(uri);
         if (!stat) {


### PR DESCRIPTION
- Mention in the readme, that a workspace has to be opened.
- Add a check to the handler to only enable the action if a workpace is open.

fixed #87

Signed-off-by: Jonas Helming <jhelming@eclipsesource.com>