### PR TITLE
Adapt import in tree template to fixed typo

### DIFF
--- a/templates/tree-editor/tree-frontend-module.ts
+++ b/templates/tree-editor/tree-frontend-module.ts
@@ -6,7 +6,7 @@ import { CommandContribution, MenuContribution } from '@theia/core';
 import { LabelProviderContribution, NavigatableWidgetOptions, OpenHandler, WidgetFactory } from '@theia/core/lib/browser';
 import URI from '@theia/core/lib/common/uri';
 import { ContainerModule } from 'inversify';
-import { createBasicTreeContainter, NavigatableTreeEditorOptions } from '@eclipse-emfcloud/theia-tree-editor';
+import { createBasicTreeContainer, NavigatableTreeEditorOptions } from '@eclipse-emfcloud/theia-tree-editor';
 
 import { TreeContribution } from './tree-contribution';
 import { TreeModelService } from './tree/tree-model-service';
@@ -38,7 +38,7 @@ export default new ContainerModule(bind => {
         id: TreeEditorWidget.WIDGET_ID,
         createWidget: (options: NavigatableWidgetOptions) => {
 
-            const treeContainer = createBasicTreeContainter(
+            const treeContainer = createBasicTreeContainer(
                 context.container,
                 TreeEditorWidget,
                 TreeModelService,


### PR DESCRIPTION
A used method from the tree editor framework used in the tree template had a typo.
This was fixed now in the latest version on npm that we pull in on install.

Original issue in the tree editor framework: https://github.com/eclipse-emfcloud/theia-tree-editor/issues/25