### PR TITLE
documentation: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@
 <br />
 <img src='https://raw.githubusercontent.com/theia-ide/generator-theia-extension/master/logo/theia.svg?sanitize=true' alt='theia logo' width='125'>
 
-<h2>THEIA - EXTENSION GENERATOR</h2>
+<h2>ECLIPSE THEIA - EXTENSION GENERATOR</h2>
+
+
 
 [![Build](https://github.com/theia-ide/generator-theia-extension/workflows/Build/badge.svg?branch=master)](https://github.com/theia-ide/generator-theia-extension/actions?query=branch%3Amaster)
+![npm](https://img.shields.io/npm/v/generator-theia-extension?color=blue)
 
-A [Yeoman](yeoman.io) generator that scaffolds a project structure for developing extensions to the [Theia IDE](https://github.com/theia-ide/theia).
+<br />
+
+A [yeoman](https://yeoman.io/) generator that scaffolds a project structure for developing [Eclipse Theia](https://github.com/eclipse-theia/theia) extensions.
+
 
 <br />
 
@@ -28,17 +34,24 @@ mkdir my-extension && cd my-extension
 yo theia-extension
 ```
 
-Extension options
-1. `hello-world`: creates a simple extension which provides a command and menu item which displays a message.
-2. `widget`: creates the basis for a simple widget including a toggle command, alert message and button displaying a message.
-3. `labelprovider`: create a simple extension which adds a custom label (with icon) for `.my` files.
-4. `tree-editor`: create a tree editor extension.
-
-For configuration options, see
+For configuration options, see:
 
 ```
 yo theia-extension --help
 ```
+
+## Extension Options
+
+
+| Template Option | Description | Documentation |
+|:---|:---|:---|
+| `hello-world` | Creates a simple extension which provides a command and menu item which displays a message | [readme](https://github.com/eclipse-theia/generator-theia-extension/blob/master/templates/hello-world/README.md) |
+| `widget` | Creates the basis for a simple widget including a toggle command, alert message and button displaying a message | [readme](https://github.com/eclipse-theia/generator-theia-extension/blob/master/templates/widget/README.md) |
+| `labelprovider` | Creates a simple extension which adds a custom label (with icon) for .my files | [readme](https://github.com/eclipse-theia/generator-theia-extension/blob/master/templates/labelprovider/README.md) |
+| `tree-editor` | Creates a tree editor extension | [readme](https://github.com/eclipse-theia/generator-theia-extension/blob/master/templates/tree-editor/README.md) |
+| `empty` | Creates a simple, minimal extension | [readme](https://github.com/eclipse-theia/generator-theia-extension/blob/master/templates/empty/README.md) |
+| `backend` | Creates a backend communication extension | [readme](https://github.com/eclipse-theia/generator-theia-extension/blob/master/templates/backend/README.md) |
+
 
 
 ## Publishing


### PR DESCRIPTION
### Description

Fixes #86 

The following commit updates the `readme` with the following changes:
- references `eclipse theia` instead of `theia`
- updates broken links
- updates re-directed links
- adds an `npm` version badge
- adds the extension options, with their appropriate documentation

### How to test:

- verify the [rendered readme](https://github.com/eclipse-theia/generator-theia-extension/blob/c667394d20dfe7ccfc3440554f90e34e16601da1/README.md).
- verify that links work correctly.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>