### PR TITLE
Add build step to generate and compile all templates

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -35,3 +35,7 @@ jobs:
       - name: Test
         shell: bash
         run: yarn test
+
+      - name: Generate and Build Templates
+        shell: bash
+        run: ./.github/workflows/generate-and-build-all-templates.sh

--- a/.github/workflows/generate-and-build-all-templates.sh
+++ b/.github/workflows/generate-and-build-all-templates.sh
@@ -1,0 +1,14 @@
+npm install -g yo
+npm link
+mkdir tmp
+cd tmp
+exit_code=0
+for d in ../templates/*/ ; do
+    extension=$(basename $d)
+    mkdir $extension
+    cd $extension
+    yo theia-extension $extension -y $extension || exit_code=$?
+    cd ..
+done
+cd ..
+exit $exit_code

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -409,7 +409,13 @@ module.exports = class TheiaExtension extends Base {
 
     install() {
         if (!(this.options as any).skipInstall) {
-            this.spawnCommand('yarn', []);
+            var command = this.spawnCommand('yarn', []);
+
+            command.on('close', function(code: number){
+                if (code !== 0 ) {
+                    process.exit(code);
+                }
+            })
         }
     }
 


### PR DESCRIPTION
Added a build step that generated and compiles a templates and fails the build if any template fails to build.
How to test: Introduce a change in a template that fails its build.
fixed #95 
Signed-off-by: Jonas Helming <jhelming@eclipsesource.com>