### PR TITLE
Fixed missing polyfills with webpack 5

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -46,6 +46,7 @@ module.exports = class TheiaExtension extends Base {
         skipInstall: boolean
         standalone: boolean
         dependencies: string
+        browserDevDependencies: string
     };
 
     constructor(args: string | string[], options: any) {
@@ -194,8 +195,10 @@ module.exports = class TheiaExtension extends Base {
         }
         if (this.params.extensionType === ExtensionType.TreeEditor) {
             this.params.dependencies = `,\n    "@theia/editor": "${this.params.theiaVersion}",\n    "@theia/filesystem": "${this.params.theiaVersion}",\n    "@theia/workspace": "${this.params.theiaVersion}",\n    "@eclipse-emfcloud/theia-tree-editor": "latest",\n    "uuid": "^3.3.2"`;
+            this.params.browserDevDependencies = `,\n    "https-browserify": "latest",\n    "stream-http": "latest",\n    "url": "latest"`;
         } else {
             this.params.dependencies = '';
+            this.params.browserDevDependencies = '';
         }
         options.params = this.params
         if (!options.standalone) {
@@ -423,3 +426,5 @@ module.exports = class TheiaExtension extends Base {
         return name.substring(0, 1).toUpperCase() + name.substring(1)
     }
 }
+
+module.exports.ExtensionType = ExtensionType;

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -23,13 +23,21 @@ module.exports = class TheiaBrowser extends Base {
     }
 
     writing() {
+        const params = (this.options as any).params
         this.fs.copyTpl(
             this.templatePath('app-browser-package.json'),
             this.destinationPath('browser-app/package.json'),
             {
                 appMode: 'browser',
-                params: (this.options as any).params
+                params
             }
         );
+        if (params.extensionType === 'tree-editor') {
+            this.fs.copyTpl(
+                this.templatePath('app-browser-webpack-config.js'),
+                this.destinationPath('browser-app/webpack.config.js'),
+                {}
+            );
+        }
     }
 }

--- a/templates/app-browser-package.json
+++ b/templates/app-browser-package.json
@@ -17,7 +17,7 @@
     "<%= params.extensionName %>": "<%= params.version %>"
   },
   "devDependencies": {
-    "@theia/cli": "<%= params.theiaVersion %>"
+    "@theia/cli": "<%= params.theiaVersion %>"<% if (params.browserDevDependencies) { %><%- params.browserDevDependencies %><% } %>
   },
   "scripts": {
     "prepare": "theia build --mode development",

--- a/templates/app-browser-webpack-config.js
+++ b/templates/app-browser-webpack-config.js
@@ -1,0 +1,22 @@
+/**
+ * This file can be edited to customize webpack configuration.
+ * To reset delete this file and rerun theia build again.
+ */
+// @ts-check
+const config = require('./gen-webpack.config.js');
+
+/**
+ * Expose bundled modules on window.theia.moduleName namespace, e.g.
+ * window['theia']['@theia/core/lib/common/uri'].
+ * Such syntax can be used by external code, for instance, for testing.
+config.module.rules.push({
+    test: /\.js$/,
+    loader: require.resolve('@theia/application-manager/lib/expose-loader')
+}); */
+
+// Load relevant node polyfills as they are no longer automatically included with webpack 5.
+config.resolve.fallback.http = require.resolve("stream-http");
+config.resolve.fallback.https = require.resolve("https-browserify");
+config.resolve.fallback.url = require.resolve("url");
+
+module.exports = config;


### PR DESCRIPTION
At least the tree-editor template failed to build because automatic nodejs polyfills were removed with webpack 5.

This extends the browser-app package.json and the browser app's configurable webpack config to polyfill node's http, https, and url modules.
Do not use a universal polyfill because theia's generated webpack config explicitly configures no fallback for multiple node modules.

Fixes #105

Signed-off-by: Lucas Koehler <lkoehler@eclipsesource.com>