### PR TITLE
Fix Tree Editor Webpack 5 Polyfills

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -195,7 +195,7 @@ module.exports = class TheiaExtension extends Base {
         }
         if (this.params.extensionType === ExtensionType.TreeEditor) {
             this.params.dependencies = `,\n    "@theia/editor": "${this.params.theiaVersion}",\n    "@theia/filesystem": "${this.params.theiaVersion}",\n    "@theia/workspace": "${this.params.theiaVersion}",\n    "@eclipse-emfcloud/theia-tree-editor": "latest",\n    "uuid": "^3.3.2"`;
-            this.params.browserDevDependencies = `,\n    "https-browserify": "latest",\n    "stream-http": "latest",\n    "url": "latest"`;
+            this.params.browserDevDependencies = `,\n    "node-polyfill-webpack-plugin": "latest"`;
         } else {
             this.params.dependencies = '';
             this.params.browserDevDependencies = '';

--- a/templates/app-browser-webpack-config.js
+++ b/templates/app-browser-webpack-config.js
@@ -14,9 +14,8 @@ config.module.rules.push({
     loader: require.resolve('@theia/application-manager/lib/expose-loader')
 }); */
 
-// Load relevant node polyfills as they are no longer automatically included with webpack 5.
-config.resolve.fallback.http = require.resolve("stream-http");
-config.resolve.fallback.https = require.resolve("https-browserify");
-config.resolve.fallback.url = require.resolve("url");
+// Load node polyfills as they are no longer automatically included with webpack 5.
+const NodePolyfillPlugin = require("node-polyfill-webpack-plugin")
+config.plugins.push(new NodePolyfillPlugin());
 
 module.exports = config;


### PR DESCRIPTION
The existing solution built fine but hang during runtime due to a missing process polyfill.
This uses a universal node polyfill for Webpack 5 to avoid such issues.

Signed-off-by: Lucas Koehler <lkoehler@eclipsesource.com>