### PR TITLE
ci: enable `workflow_dispatch`

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Fixes: https://github.com/eclipse-theia/generator-theia-extension/issues/136.

The commit enables the `workflow_dispatch` so we can manually trigger CI when needed.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>