### PR TITLE
tree-editor: fix deprecations

### DIFF
--- a/templates/tree-editor/tree-label-provider-contribution.ts
+++ b/templates/tree-editor/tree-label-provider-contribution.ts
@@ -1,14 +1,15 @@
 import { LabelProviderContribution } from '@theia/core/lib/browser';
 import URI from '@theia/core/lib/common/uri';
-import { FileStat } from '@theia/filesystem/lib/common';
+import { FileStat } from '@theia/filesystem/lib/common/files';
 import { injectable } from '@theia/core/shared/inversify';
 
 @injectable()
 export class TreeLabelProviderContribution implements LabelProviderContribution {
-    canHandle(uri: object): number {
-        let toCheck = uri;
+
+    canHandle(element: object): number {
+        let toCheck = element;
         if (FileStat.is(toCheck)) {
-            toCheck = new URI(toCheck.uri);
+            toCheck = toCheck.resource;
         }
         if (toCheck instanceof URI) {
             if (toCheck.path.ext === '.tree') {
@@ -21,6 +22,6 @@ export class TreeLabelProviderContribution implements LabelProviderContribution 
     getIcon(): string {
         return 'fa fa-coffee dark-purple';
     }
-    
+
     // We don't need to specify getName() nor getLongName() because the default uri label provider is responsible for them.
 }


### PR DESCRIPTION
**Description**

Fixes: https://github.com/eclipse-theia/generator-theia-extension/issues/148.
The pull-request fixes the `tree-editor` following the removal of deprecations upstream.

**Steps to Test**:

1. clone the repo and checkout the branch
2. perform `npm link`
3. create directory and navigate to it
4. perform `yo theia-extension`
5. select `TreeEditor` from the list of templates
6. confirm that the generation and functionality afterwards works

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>