### PR TITLE
ci: update node version

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04]
-        node: [12]
+        node: [16]
 
     steps:
       - name: Checkout
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04]
-        node: [12]
+        node: [16]
 
     steps:
       - name: Checkout
@@ -72,7 +72,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04]
-        node: [12]
+        node: [16]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
**Description**

Fixes: https://github.com/eclipse-theia/generator-theia-extension/issues/151.
The pull-request updates the Node version in CI from v12 to v16 (LTS) similarly to the main repository.

**How to Test**

Confirm that CI passes.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>