### PR TITLE
Add `theia check:theia-version` by default

### DIFF
--- a/templates/root-package.json
+++ b/templates/root-package.json
@@ -2,6 +2,7 @@
   "private": true,
   "scripts": {
     "prepare": "lerna run prepare",
+    "postinstall": "theia check:theia-version",
     "rebuild:browser": "theia rebuild:browser",
     "rebuild:electron": "theia rebuild:electron",
     "start:browser": "yarn rebuild:browser && yarn --cwd browser-app start",


### PR DESCRIPTION
This will run the Theia version check after yarn install to check whether multiple versions of @theia/* packages are pulled by direct or indirect dependencies.

See also https://github.com/eclipse-theia/theia/pull/11483

Contributed on behalf of STMicroelectronics.

### Testing this PR

* Run `npm link` in this repo location on your disk
* Go to another location and generate a new hello world Theia application
  * `cd ~ && mkdir hello-world && cd hello-world`
  * `yo theia-extension` -- select "Hello World"
  * Wait for the build to finish
* Add for instance `"@theia/cpp-debug": "latest",` as a dependency to `browser-app/package.json`
* Run `yarn` and observe how now the build fails due to the Theia version check :ballot_box_with_check: