### PR TITLE
repo: add updated information to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "generator-theia-extension",
   "version": "0.1.32",
+  "engines": {
+    "yarn": ">=1.7.0 <2",
+    "node": ">=14.18.0"
+  },
   "description": "Helps to setup the project structure for developing extensions to the Theia IDE",
   "repository": {
     "type": "git",

--- a/templates/README.md
+++ b/templates/README.md
@@ -3,18 +3,7 @@ The example of how to build the Theia-based applications with the <%= params.ext
 
 ## Getting started
 
-Install [nvm](https://github.com/creationix/nvm#install-script).
-
-    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
-
-Install npm and node.
-
-    nvm install 10
-    nvm use 10
-
-Install yarn.
-
-    npm install -g yarn
+Please install all necessary [prerequisites](https://github.com/eclipse-theia/theia/blob/master/doc/Developing.md#prerequisites).
 
 ## Running the browser example
 
@@ -51,7 +40,7 @@ Open http://localhost:3000 in the browser.
 
     cd <%= params.extensionPath %>
     yarn test
-    
+
 <%}%>
 ## Developing with the browser example
 

--- a/templates/root-package.json
+++ b/templates/root-package.json
@@ -1,5 +1,9 @@
 {
   "private": true,
+  "engines": {
+    "yarn": ">=1.7.0 <2",
+    "node": ">=14.18.0"
+  },
   "scripts": {
     "prepare": "lerna run prepare",
     "rebuild:browser": "theia rebuild:browser",


### PR DESCRIPTION
**What it does**

Closes https://github.com/eclipse-theia/generator-theia-extension/issues/109.
Closes https://github.com/eclipse-theia/generator-theia-extension/issues/154.

The commit updates the generator by:
- setting the `engines` for the repo and templates to allowed node versions
- updating the `prerequisites` documentation to point to the original source found in the main repository so it does not get outdated.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>