### PR TITLE
repo: fix build errors due to `typescript` and ci

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-latest]
         node: [16]
 
     steps:
@@ -44,7 +44,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-latest]
         node: [16]
 
     steps:
@@ -71,7 +71,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-latest]
         node: [16]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/yeoman-generator": "^3.1.4",
     "mocha": "^6.2.0",
     "rimraf": "^3.0.0",
-    "typescript": "^3.6.3",
+    "typescript": "~4.5.5",
     "yeoman-assert": "^3.1.1",
     "yeoman-test": "^2.0.0"
   },

--- a/templates/extension-package.json
+++ b/templates/extension-package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "rimraf": "latest",
-    "typescript": "latest"<% if (params.devdependencies) { %><%- params.devdependencies %><% } %>
+    "typescript": "~4.5.5"<% if (params.devdependencies) { %><%- params.devdependencies %><% } %>
   },
   "scripts": {
     "prepare": "yarn run clean && yarn run build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2957,10 +2957,10 @@ type-fest@^0.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
-typescript@^3.6.3:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
-  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+typescript@~4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
**Description**

Closes: #164.

The pull-request pins the `typescript` version to the version supported and used by the Eclipse Theia framework for compatibility reasons.