### PR TITLE
Generated electron-app does not work anymore #166

### DIFF
--- a/templates/app-electron-package.json
+++ b/templates/app-electron-package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@theia/cli": "<%= params.theiaVersion %>",
-    "electron": "^15.3.5"
+    "electron": "^23.2.4"
   },
   "scripts": {
     "prepare": "theia build --mode development",


### PR DESCRIPTION
I think there are two fixes for this. 

The first one would be to simply update the electron version in our template. However I believe with our recent changes, we may more easily update electron in the future. So this might change more often, requiring more regular fixes. 

The second fix would be to remove the electron version from the template completely. 
When we invoke `yarn` for the first time, the theia build will patch the `package.json` and add the supported electron version. This requires a second invocation of `yarn` however, in order to install electron. 
So in the electron case we have to run `yarn` twice, when the electron version is removed from the template. 

Fixes #166