### PR TITLE
Fix breaking change after inversify update

### DIFF
--- a/templates/widget/widget.tsx
+++ b/templates/widget/widget.tsx
@@ -15,7 +15,11 @@ export class <%= params.extensionPrefix %>Widget extends ReactWidget {
     protected readonly messageService!: MessageService;
 
     @postConstruct()
-    protected async init(): Promise < void> {
+    protected async init(): void {
+        this.doInit()
+    }
+
+    protected async doInit(): Promise < void> {
         this.id = <%= params.extensionPrefix %>Widget.ID;
         this.title.label = <%= params.extensionPrefix %>Widget.LABEL;
         this.title.caption = <%= params.extensionPrefix %>Widget.LABEL;

--- a/templates/widget/widget.tsx
+++ b/templates/widget/widget.tsx
@@ -15,11 +15,11 @@ export class <%= params.extensionPrefix %>Widget extends ReactWidget {
     protected readonly messageService!: MessageService;
 
     @postConstruct()
-    protected async init(): void {
+    protected init(): void {
         this.doInit()
     }
 
-    protected async doInit(): Promise < void> {
+    protected async doInit(): Promise <void> {
         this.id = <%= params.extensionPrefix %>Widget.ID;
         this.title.label = <%= params.extensionPrefix %>Widget.LABEL;
         this.title.caption = <%= params.extensionPrefix %>Widget.LABEL;


### PR DESCRIPTION
With the latest Theia version (v1.39.0), components that use `@postConstruct()` are no longer allowed to return a promise in that function. This change fixes the issue in the widget that we distribute.