### PR TITLE
Update scripts to work with 1.39 and earlier Theia releases #170

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -7,11 +7,12 @@ Please install all necessary [prerequisites](https://github.com/eclipse-theia/th
 
 ## Running the browser example
 
+    yarn build:browser
     yarn start:browser
 
 *or:*
 
-    yarn rebuild:browser
+    yarn build:browser
     cd browser-app
     yarn start
 
@@ -21,11 +22,12 @@ Open http://localhost:3000 in the browser.
 
 ## Running the Electron example
 
+    yarn build:electron
     yarn start:electron
 
 *or:*
 
-    yarn rebuild:electron
+    yarn build:electron
     cd electron-app
     yarn start
 

--- a/templates/app-browser-package.json
+++ b/templates/app-browser-package.json
@@ -20,9 +20,10 @@
     "@theia/cli": "<%= params.theiaVersion %>"<% if (params.browserDevDependencies) { %><%- params.browserDevDependencies %><% } %>
   },
   "scripts": {
-    "prepare": "theia build --mode development",
+    "bundle": "yarn rebuild && theia build --mode development",
+    "rebuild": "theia rebuild:browser",
     "start": "theia start",
-    "watch": "theia build --watch --mode development"
+    "watch": "yarn rebuild && theia build --watch --mode development"
   },
   "theia": {
     "target": "<%= appMode %>"

--- a/templates/app-electron-package.json
+++ b/templates/app-electron-package.json
@@ -22,9 +22,10 @@
     "electron": "^23.2.4"
   },
   "scripts": {
-    "prepare": "theia build --mode development",
+    "bundle": "yarn rebuild && theia build --mode development",
+    "rebuild": "theia rebuild:electron",
     "start": "theia start",
-    "watch": "theia build --watch --mode development"
+    "watch": "yarn rebuild && theia build --watch --mode development"
   },
   "theia": {
     "target": "<%= appMode %>"

--- a/templates/root-package.json
+++ b/templates/root-package.json
@@ -5,12 +5,12 @@
     "node": ">=14.18.0"
   },
   "scripts": {
+    "build:browser": "yarn --cwd browser-app bundle",
+    "build:electron": "yarn --cwd electron-app bundle",
     "prepare": "lerna run prepare",
     "postinstall": "theia check:theia-version",
-    "rebuild:browser": "theia rebuild:browser",
-    "rebuild:electron": "theia rebuild:electron",
-    "start:browser": "yarn rebuild:browser && yarn --cwd browser-app start",
-    "start:electron": "yarn rebuild:electron && yarn --cwd electron-app start",
+    "start:browser": "yarn --cwd browser-app start",
+    "start:electron": "yarn --cwd electron-app start",
     "watch": "lerna run --parallel watch"<% if (params.rootscripts) { %><%- params.rootscripts %><% } %>
   },
   "devDependencies": {


### PR DESCRIPTION
* rebuild needs to be run performed before build

Steps to reproduce issues with released version of generator
```
mkdir my-extension-38 && cd my-extension-38
yo theia-extension -t 1.38.0
<Enter> (Hello World extension type)
<Enter> (hello-world extension name)
yarn start:browser
yarn start:electron

mkdir my-extension-39 && cd my-extension-39
yo theia-extension -t 1.39.0
<Enter> (Hello World extension type)
<Enter> (hello-world extension name)
yarn start:browser
yarn start:electron
```

Steps to test including fixes in this PR:
```
mkdir my-extension-38 && cd my-extension-38
yo theia-extension -t 1.38.0
<Enter> (Hello World extension type)
<Enter> (hello-world extension name)
yarn build:browser
yarn start:browser
yarn build:electron
yarn start:electron

mkdir my-extension-39 && cd my-extension-39
yo theia-extension -t 1.39.0
<Enter> (Hello World extension type)
<Enter> (hello-world extension name)
yarn build:browser
yarn start:browser
yarn build:electron
yarn start:electron
```