### PR TITLE
Fix launch configs for 1.39.0 and earlier versions

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -21,6 +21,8 @@ const tar = require('tar');
 const fs = require('fs-extra');
 
 const glspExamplesRepositoryTag = "generator-latest";
+const backend = "backend";
+const frontend = "frontend";
 
 enum ExtensionType {
     HelloWorld = 'hello-world',
@@ -63,6 +65,7 @@ module.exports = class TheiaExtension extends Base {
         scripts: string
         rootscripts: string
         containsTests: boolean
+        electronMainLocation: string
     };
 
     constructor(args: string | string[], options: any) {
@@ -238,7 +241,8 @@ module.exports = class TheiaExtension extends Base {
             githubURL,
             theiaVersion: options["theia-version"],
             lernaVersion: options["lerna-version"],
-            backend: options["extensionType"] === ExtensionType.Backend
+            backend: options["extensionType"] === ExtensionType.Backend,
+            electronMainLocation: this.getElectronMainLocation(options["theia-version"])
         }
         this.params.dependencies = '';
         this.params.browserDevDependencies = '';
@@ -529,6 +533,24 @@ module.exports = class TheiaExtension extends Base {
     private _capitalize(name: string): string {
         return name.substring(0, 1).toUpperCase() + name.substring(1)
     }
+
+    private getElectronMainLocation(theiaVersion: string): string {
+        try {
+            const semVer = theiaVersion.split('.');
+            if (semVer.length < 3) {
+                return backend;
+            }
+            const major = Number(semVer[0]);
+            const minor = Number(semVer[1]);
+            if ((major === 0) || (major === 1 && minor < 39)) {
+                return frontend;
+            }
+            return backend;
+        } catch (e) {
+            return backend;
+        }
+    }
 }
 
 module.exports.ExtensionType = ExtensionType;
+

--- a/templates/launch.json
+++ b/templates/launch.json
@@ -35,7 +35,7 @@
             "windows": {
                 "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
             },
-            "program": "${workspaceRoot}/electron-app/src-gen/frontend/electron-main.js",
+            "program": "${workspaceRoot}/electron-app/src-gen/<%= params.electronMainLocation %>/electron-main.js",
             "protocol": "inspector",
             "args": [
                 "--loglevel=debug",
@@ -47,7 +47,7 @@
             },
             "sourceMaps": true,
             "outFiles": [
-                "${workspaceRoot}/electron-app/src-gen/frontend/electron-main.js",
+                "${workspaceRoot}/electron-app/src-gen/<%= params.electronMainLocation %>/electron-main.js",
                 "${workspaceRoot}/electron-app/src-gen/backend/main.js",
                 "${workspaceRoot}/*/lib/**/*.js",
                 "${workspaceRoot}/node_modules/@theia/*/lib/**/*.js"


### PR DESCRIPTION
Because of the move of `electron-main` from `frontend` to `backend`we have to adjust the launch configurations as well. 

**Tests**

mkdir my-extension-38 && cd my-extension-38
yo theia-extension -t 1.38.0
<Enter> (Hello World extension type)
<Enter> (hello-world extension name)
yarn build:electron
Use "Start Electron Backend" launch config

mkdir my-extension-39 && cd my-extension-39
yo theia-extension -t 1.39.0
<Enter> (Hello World extension type)
<Enter> (hello-world extension name)
yarn build:electron
Use "Start Electron Backend" launch config

mkdir my-extension-latest && cd my-extension-latest
yo theia-extension
<Enter> (Hello World extension type)
<Enter> (hello-world extension name)
yarn build:electron
Use "Start Electron Backend" launch config