### PR TITLE
tree-editor: add missing jsonforms peer dependencies

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -247,7 +247,7 @@ module.exports = class TheiaExtension extends Base {
         this.params.dependencies = '';
         this.params.browserDevDependencies = '';
         if (this.params.extensionType === ExtensionType.TreeEditor) {
-            this.params.dependencies = `,\n    "@theia/editor": "${this.params.theiaVersion}",\n    "@theia/filesystem": "${this.params.theiaVersion}",\n    "@theia/workspace": "${this.params.theiaVersion}",\n    "@eclipse-emfcloud/theia-tree-editor": "next",\n    "uuid": "^3.3.2"`;
+            this.params.dependencies = `,\n    "@theia/editor": "${this.params.theiaVersion}",\n    "@theia/filesystem": "${this.params.theiaVersion}",\n    "@theia/workspace": "${this.params.theiaVersion}",\n    "@eclipse-emfcloud/theia-tree-editor": "next",\n    "@jsonforms/core": "^3.1.0",\n    "@jsonforms/react": "^3.1.0",\n    "@jsonforms/vanilla-renderers": "^3.1.0",\n    "uuid": "^3.3.2"`;
         }
         if (this.params.extensionType === ExtensionType.Widget) {
             this.params.devdependencies = `,\n    "@testing-library/react": "^11.2.7",\n    "@types/jest": "^26.0.20",\n    "jest": "^26.6.3",\n    "ts-node": "^10.9.1",\n    "ts-jest": "^26.5.6"`;


### PR DESCRIPTION
The tree editor framework was updated to require jsonforms as peer dependencies instead of direct dependencies. Thus, they were no longer installed. This commit adds them to the generated tree extension.

See also https://github.com/eclipse-emfcloud/theia-tree-editor/issues/78

Contributed on behalf of STMicroelectronics