### PR TITLE
fix: specify cacheRoot for rebuilds

### DIFF
--- a/templates/app-browser-package.json
+++ b/templates/app-browser-package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "bundle": "yarn rebuild && theia build --mode development",
-    "rebuild": "theia rebuild:browser",
+    "rebuild": "theia rebuild:browser --cacheRoot ..",
     "start": "theia start",
     "watch": "yarn rebuild && theia build --watch --mode development"
   },

--- a/templates/app-electron-package.json
+++ b/templates/app-electron-package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "bundle": "yarn rebuild && theia build --mode development",
-    "rebuild": "theia rebuild:electron",
+    "rebuild": "theia rebuild:electron --cacheRoot ..",
     "start": "theia start",
     "watch": "yarn rebuild && theia build --watch --mode development"
   },


### PR DESCRIPTION
Sets the 'cacheRoot' of 'theia rebuild' to the root directory as is done in the Theia repository. This is needed so that 'theia rebuild' is able to appropriatly determine the state of the native builds.

fixes #190