### PR TITLE
fix: specify main entry for Electron

### DIFF
--- a/templates/app-electron-package.json
+++ b/templates/app-electron-package.json
@@ -2,6 +2,7 @@
   "private": true,
   "name": "<%= appMode %>-app",
   "version": "<%= params.version %>",
+  "main": "lib/backend/electron-main.js",
   "dependencies": {
     "@theia/core": "<%= params.theiaVersion %>",
     "@theia/editor": "<%= params.theiaVersion %>",


### PR DESCRIPTION
Specifies the main entry of the Theia Electron application to use the bundled backend. This avoids the Theia CLI warning that the "main" entry is missing.