### PR TITLE
chore: update  Node version constraint

### DIFF
--- a/templates/root-package.json
+++ b/templates/root-package.json
@@ -2,7 +2,7 @@
   "private": true,
   "engines": {
     "yarn": ">=1.7.0 <2",
-    "node": ">=14.18.0"
+    "node": ">=16"
   },
   "scripts": {
     "build:browser": "yarn --cwd browser-app bundle",


### PR DESCRIPTION
Updates the generate Node version constraint to the same one of the main Theia repository. See [here](https://github.com/eclipse-theia/theia/blob/aeee293abca62856cacdfdc67a03ed76ebaa81ad/package.json#L7).