### PR TITLE
fix: remove protocol from launch configuration

### DIFF
--- a/templates/launch.json
+++ b/templates/launch.json
@@ -36,7 +36,6 @@
                 "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
             },
             "program": "${workspaceRoot}/electron-app/src-gen/<%= params.electronMainLocation %>/electron-main.js",
-            "protocol": "inspector",
             "args": [
                 "--loglevel=debug",
                 "--hostname=localhost",


### PR DESCRIPTION
"protocol" is an outdated property of the "node" launch configuration. It is now removed from the generator.