### PR TITLE
Change launch.json to launch the bundled app instead of the unbundled app

### DIFF
--- a/templates/launch.json
+++ b/templates/launch.json
@@ -8,7 +8,7 @@
             "type": "node",
             "request": "launch",
             "name": "Start Browser Backend",
-            "program": "${workspaceRoot}/browser-app/src-gen/backend/main.js",
+            "program": "${workspaceRoot}/browser-app/lib/backend/main.js",
             "args": [
                 "--loglevel=debug",
                 "--port=3000",
@@ -21,7 +21,7 @@
             "outFiles": [
                 "${workspaceRoot}/node_modules/@theia/*/lib/**/*.js",
                 "${workspaceRoot}/*/lib/**/*.js",
-                "${workspaceRoot}/browser-app/src-gen/**/*.js"
+                "${workspaceRoot}/browser-app/lib/**/*.js"
             ],
             "smartStep": true,
             "internalConsoleOptions": "openOnSessionStart",
@@ -35,7 +35,7 @@
             "windows": {
                 "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
             },
-            "program": "${workspaceRoot}/electron-app/src-gen/<%= params.electronMainLocation %>/electron-main.js",
+            "program": "${workspaceRoot}/electron-app/lib/<%= params.electronMainLocation %>/electron-main.js",
             "args": [
                 "--loglevel=debug",
                 "--hostname=localhost",
@@ -46,8 +46,8 @@
             },
             "sourceMaps": true,
             "outFiles": [
-                "${workspaceRoot}/electron-app/src-gen/<%= params.electronMainLocation %>/electron-main.js",
-                "${workspaceRoot}/electron-app/src-gen/backend/main.js",
+                "${workspaceRoot}/electron-app/lib/<%= params.electronMainLocation %>/electron-main.js",
+                "${workspaceRoot}/electron-app/lib/backend/main.js",
                 "${workspaceRoot}/*/lib/**/*.js",
                 "${workspaceRoot}/node_modules/@theia/*/lib/**/*.js"
             ],


### PR DESCRIPTION
As part of the generated code, a .vscode/launch.json file is generated.

That generated file contains launches for the Electron and Browser backends.

The problem is that the launches point to the apps in src-gen which leads to errors as the one reported in https://github.com/eclipse-theia/theia/discussions/15323

This PR adjusts the launches to reference the files in `lib/` instead of `src-gen/` in the launched app and the sourceMaps.


To reproduce the original error, try to generate the code, add all Theia packages to the package.json of either of the applications (browser or electron) and try to launch:
```
 "dependencies": {
    "@theia/ai-anthropic": "1.62.0",
    "@theia/ai-chat": "1.62.0",
    "@theia/ai-chat-ui": "1.62.0",
    "@theia/ai-code-completion": "1.62.0",
    "@theia/ai-core": "1.62.0",
    "@theia/ai-google": "1.62.0",
    "@theia/ai-history": "1.62.0",
    "@theia/ai-huggingface": "1.62.0",
    "@theia/ai-ide": "1.62.0",
    "@theia/ai-llamafile": "1.62.0",
    "@theia/ai-mcp": "1.62.0",
    "@theia/ai-ollama": "1.62.0",
    "@theia/ai-openai": "1.62.0",
    "@theia/ai-scanoss": "1.62.0",
    "@theia/ai-terminal": "1.62.0",
    "@theia/bulk-edit": "1.62.0",
    "@theia/callhierarchy": "1.62.0",
    "@theia/collaboration": "1.62.0",
    "@theia/console": "1.62.0",
    "@theia/core": "1.62.0",
    "@theia/debug": "1.62.0",
    "@theia/dev-container": "1.62.0",
    "@theia/editor": "1.62.0",
    "@theia/editor-preview": "1.62.0",
    "@theia/electron": "1.62.0",
    "@theia/external-terminal": "1.62.0",
    "@theia/file-search": "1.62.0",
    "@theia/filesystem": "1.62.0",
    "@theia/getting-started": "1.62.0",
    "@theia/keymaps": "1.62.0",
    "@theia/markers": "1.62.0",
    "@theia/memory-inspector": "1.62.0",
    "@theia/messages": "1.62.0",
    "@theia/metrics": "1.62.0",
    "@theia/mini-browser": "1.62.0",
    "@theia/monaco": "1.62.0",
    "@theia/navigator": "1.62.0",
    "@theia/outline-view": "1.62.0",
    "@theia/output": "1.62.0",
    "@theia/plugin-dev": "1.62.0",
    "@theia/plugin-ext": "1.62.0",
    "@theia/plugin-ext-headless": "1.62.0",
    "@theia/plugin-ext-vscode": "1.62.0",
    "@theia/preferences": "1.62.0",
    "@theia/preview": "1.62.0",
    "@theia/process": "1.62.0",
    "@theia/property-view": "1.62.0",
    "@theia/remote": "1.62.0",
    "@theia/remote-wsl": "1.62.0",
    "@theia/scanoss": "1.62.0",
    "@theia/scm": "1.62.0",
    "@theia/scm-extra": "1.62.0",
    "@theia/search-in-workspace": "1.62.0",
    "@theia/secondary-window": "1.62.0",
    "@theia/task": "1.62.0",
    "@theia/terminal": "1.62.0",
    "@theia/timeline": "1.62.0",
    "@theia/toolbar": "1.62.0",
    "@theia/typehierarchy": "1.62.0",
    "@theia/userstorage": "1.62.0",
    "@theia/variable-resolver": "1.62.0",
    "@theia/vsx-registry": "1.62.0",
    "@theia/workspace": "1.62.0"
 }
 ```





